### PR TITLE
Eliminar indicadores Mig

### DIFF
--- a/Base/base.do
+++ b/Base/base.do
@@ -330,36 +330,6 @@ use "`base_in'", clear
       *****************
     gen spublico_ci=(indgen==100)	
 
-***********************************
-***    VARIABLES DE MIGRACIÓN.  ***
-***********************************
-			
-
-      *******************
-      ****migrante_ci****
-      *******************
-	gen migrante_ci =.
-	cap confirm variable nativity
-	if (_rc==0) {
-	replace migrante_ci=(nativity == 2)
-	
-	}
-      *******************
-      **migantiguo5_ci***
-      *******************
-	gen migantiguo5_ci =.
-	cap confirm variable yrsimm 
-	if (_rc==0) {
-	replace migantiguo5_ci=(yrsimm >= 5)
-	replace migantiguo5_ci = . if (yrsimm == 99 | yrsimm == 98)
-	}
-
-		**********************
-		*** migrantelac_ci ***
-		**********************
-
-		gen migrantelac_ci= .
-
 
 		**********************************
 		**** VARIABLES DE LA VIVIENDA ****


### PR DESCRIPTION
Dado que los indicadores Mig no iban a ser medidos a través del Do Base, los eliminé para mejor calcularlos después por cada país y año. De todas formas muchas gracias por tu ayuda, @linarias8. 